### PR TITLE
Moving core to threads

### DIFF
--- a/src/main/Host.js
+++ b/src/main/Host.js
@@ -170,22 +170,30 @@ const initHandlers = async () => {
 
 	WSSHost.addReducer(requestChannels.invokeLaunch, async (data) => {
 		if (!data.version_hash) return false;
-		setImmediate(() => launchMinecraft(data.version_hash, data.params = {}, {
-			load: (data) => WSSHost.emit(ackChannels.gameProgressLoad, data),
-			download: (data) => WSSHost.emit(ackChannels.gameProgressDownload, data),
-			close: (data) => {
-				MainWindow.setProgressBar(-1);
-				WSSHost.emit(ackChannels.gameStartupError, data);
-			},
-			success: (data) => {
-				MainWindow.setProgressBar(-1);
-				WSSHost.emit(ackChannels.gameStartupSuccess, data);
-			},
-			error: (data) => {
-				MainWindow.setProgressBar(-1);
-				WSSHost.emit(ackChannels.gameError, data);
-			},
-		}));
+		const eventListener = (event, args) => {
+			switch (event) {
+				case 'download': {
+					WSSHost.emit(ackChannels.gameProgressDownload, args);
+				}; break;
+				case 'progress': {
+					WSSHost.emit(ackChannels.gameProgressLoad, args);
+				}; break;
+				case 'close': {
+					MainWindow.setProgressBar(-1);
+					WSSHost.emit(ackChannels.gameStartupError, args);
+				}; break;
+				case 'success': {
+					MainWindow.setProgressBar(-1);
+					WSSHost.emit(ackChannels.gameStartupSuccess, args);
+				}; break;
+				case 'error': {
+					MainWindow.setProgressBar(-1);
+					WSSHost.emit(ackChannels.gameError, args);
+				}; break;
+				default: break;
+			}
+		}
+		setImmediate(() => launchMinecraft(data.version_hash, data.params = {}, eventListener));
 		return true;
 	});
 

--- a/src/main/Launcher.js
+++ b/src/main/Launcher.js
@@ -2,23 +2,42 @@ const { createInstance } = require('./managers/InstanceManager');
 
 const logger = require('./util/loggerutil')('%c[Main-Launch]', 'color: #ff2119; font-weight: bold;');
 
-exports.launchMinecraft = async (version_hash, params = {}) => {
-	const Host = require('./Host');
+const { Worker } = require("node:worker_threads");
+const path = require('node:path');
+
+
+const getJava = async (launcherOptions) => {
+	const JavaManager = require('./managers/JavaManager');
+	const javaPath = launcherOptions?.installation?.javaPath || launcherOptions?.java?.javaPath || 'javaw';
+	const java = await JavaManager.checkJava(javaPath);
+	if (!java.run) {
+			this.debug && logger.error(`Couldn't start Minecraft due to: ${java.message}`);
+			throw new Error(`Wrong java (${javaPath})`);
+	}
+	return javaPath;
+}
+
+const launchMinecraft = async (version_hash, params = {}, events = {
+	load: void 0,
+	download: void 0,
+	close: void 0,
+	success: void 0,
+	error: void 0,
+}) => {
 	const ConfigManager = require('./managers/ConfigManager');
 	const VersionManager = require('./managers/VersionManager');
 	const InstallationsManager = require('./managers/InstallationsManager');
-	const MainWindow = require('./MainWindow');
 
 	if (!version_hash) throw new Error("version_hash is required");
 
 	const currentInstallation = await InstallationsManager.getInstallation(version_hash);
 	if (!currentInstallation) throw new Error("Installation does not exist on given hash");
 
-	const GameLauncher = require('./game/launcher');
+	const versionFile = await VersionManager.getVersionManifest(currentInstallation.lastVersionId);
 
 	function progress(e) {
 		const progress = (e.task / e.total);
-		Host.Bridge.emit(Host.ackChannels.gameProgressLoad, {
+		events.load != void 0 && events.load({
 			type: e.type,
 			progress: progress,
 			version_hash: version_hash,
@@ -28,16 +47,18 @@ exports.launchMinecraft = async (version_hash, params = {}) => {
 	function download_progress(e) {
 		const progress = (e.current / e.total);
 		if (e.type != 'version-jar') return;
-		Host.Bridge.emit(Host.ackChannels.gameProgressDownload, {
+		events.download != void 0 && events.download({
 			type: e.type,
 			progress: progress,
 			version_hash: version_hash,
 		});
 	}
 
+
 	try {
 
 		const launcherOptions = Object.assign({}, ConfigManager.getAllOptionsSync(), {
+			manifest: versionFile,
 			installation: currentInstallation,
 			auth: {
 				access_token: undefined,
@@ -47,54 +68,68 @@ exports.launchMinecraft = async (version_hash, params = {}) => {
 			}
 		}, params);
 
-		const launcher = new GameLauncher(launcherOptions);
-		launcher.on('progress', progress);
-		launcher.on('download-status', download_progress);
-
-		const javaPath = await launcher.getJava();
-		const minecraftArguments = await launcher.construct();
-		const jvm = await createInstance(version_hash, javaPath, minecraftArguments, {
-			cwd: launcherOptions.java.cwd || launcherOptions.overrides.path.root,
-      detached: launcherOptions.java.detached
+		const javaPath = await getJava(launcherOptions);
+		const worker = new Worker(path.resolve(__dirname, "game/launcher.js"), {
+			workerData: launcherOptions
 		});
 
+		// worker.on('progress', progress);
+		// worker.on('download-status', download_progress);
 
-		let error_out = null,
-			std_out = null,
-			logg_out = null;
-
-		jvm.stderr.on('data', (data) => {
-			logg_out = error_out = data.toString('utf-8');
+		worker.on('message', async ({ type, payload }) => {
+			if (type != 'progress') return;
+			progress(payload);
 		});
 
-		jvm.stdout.on('data', (data) => {
-			logg_out = std_out = data.toString('utf-8');
+		worker.on('message', async ({ type, payload }) => {
+			if (type != 'download-progress') return;
+			download_progress(payload);
 		});
 
-		jvm.on('close', (code) => {
-			if (![null, 0, 143].includes(code)) {
-				MainWindow.setProgressBar(-1);
-				Host.Bridge.emit(Host.ackChannels.gameStartupError, {
-					error: logg_out,
-					version_hash: version_hash
-				});
-			}
-		});
+		worker.on('message', async ({ type, payload }) => {
+			if (type != 'args') return;
 
-		MainWindow.setProgressBar(-1);
-		Host.Bridge.emit(Host.ackChannels.gameStartupSuccess, {
-			version_hash: version_hash
-		});
+			const jvm = await createInstance(version_hash, javaPath, payload, {
+				cwd: launcherOptions.java.cwd || launcherOptions.overrides.path.root,
+				detached: launcherOptions.java.detached
+			});
+
+			let error_out = null,
+				std_out = null,
+				logg_out = null;
+
+			jvm.stderr.on('data', (data) => {
+				logg_out = error_out = data.toString('utf-8');
+			});
+
+			jvm.stdout.on('data', (data) => {
+				logg_out = std_out = data.toString('utf-8');
+			});
+
+			jvm.on('close', (code) => {
+				if (![null, 0, 143].includes(code)) {
+					events.close != void 0 && events.close({
+						error: logg_out,
+						version_hash: version_hash
+					});
+				}
+			});
+
+			events.success != void 0 && events.success({
+				version_hash: version_hash
+			});
+		})
 
 		return true;
 
 	} catch (error) {
 		logger.error(error);
-		MainWindow.setProgressBar(-1);
-		Host.Bridge.emit(Host.ackChannels.gameError, {
+		events.error != void 0 && events.error({
 			error: error.message,
 			version_hash: version_hash
 		});
 	}
 	return false;
 }
+
+module.exports = launchMinecraft;


### PR DESCRIPTION
Move Minecraft and launcher cores to threads worker to increase performance and prevent main window lagging while startup tasks running